### PR TITLE
Support more field filters and handle repeated fields

### DIFF
--- a/src/main/cc/wfa/virtual_people/common/field_filter/BUILD.bazel
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/BUILD.bazel
@@ -10,6 +10,7 @@ cc_library(
         "and_filter.cc",
         "equal_filter.cc",
         "field_filter.cc",
+        "or_filter.cc",
         "partial_filter.cc",
         "true_filter.cc",
     ],
@@ -17,6 +18,7 @@ cc_library(
         "and_filter.h",
         "equal_filter.h",
         "field_filter.h",
+        "or_filter.h",
         "partial_filter.h",
         "true_filter.h",
     ],
@@ -52,6 +54,22 @@ cc_test(
 cc_test(
     name = "equal_filter_test",
     srcs = ["equal_filter_test.cc"],
+    deps = [
+        ":field_filter",
+        "//src/main/cc/wfa/virtual_people/common/field_filter/test:test_cc_proto",
+        "//src/main/proto/wfa/virtual_people/common:field_filter_cc_proto",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
+        "@cross_media_measurement//src/test/cc/testutil:matchers",
+        "@cross_media_measurement//src/test/cc/testutil:status_macros",
+    ],
+)
+
+cc_test(
+    name = "or_filter_test",
+    srcs = ["or_filter_test.cc"],
     deps = [
         ":field_filter",
         "//src/main/cc/wfa/virtual_people/common/field_filter/test:test_cc_proto",

--- a/src/main/cc/wfa/virtual_people/common/field_filter/BUILD.bazel
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/BUILD.bazel
@@ -10,6 +10,7 @@ cc_library(
         "and_filter.cc",
         "equal_filter.cc",
         "field_filter.cc",
+        "has_filter.cc",
         "not_filter.cc",
         "or_filter.cc",
         "partial_filter.cc",
@@ -19,6 +20,7 @@ cc_library(
         "and_filter.h",
         "equal_filter.h",
         "field_filter.h",
+        "has_filter.h",
         "not_filter.h",
         "or_filter.h",
         "partial_filter.h",
@@ -46,6 +48,22 @@ cc_test(
         ":field_filter",
         "//src/main/cc/wfa/virtual_people/common/field_filter/test:test_cc_proto",
         "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
+        "@cross_media_measurement//src/test/cc/testutil:matchers",
+        "@cross_media_measurement//src/test/cc/testutil:status_macros",
+    ],
+)
+
+cc_test(
+    name = "has_filter_test",
+    srcs = ["has_filter_test.cc"],
+    deps = [
+        ":field_filter",
+        "//src/main/cc/wfa/virtual_people/common/field_filter/test:test_cc_proto",
+        "//src/main/proto/wfa/virtual_people/common:field_filter_cc_proto",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest_main",
         "@com_google_protobuf//:protobuf",
         "@cross_media_measurement//src/test/cc/testutil:matchers",

--- a/src/main/cc/wfa/virtual_people/common/field_filter/BUILD.bazel
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/BUILD.bazel
@@ -10,6 +10,7 @@ cc_library(
         "and_filter.cc",
         "equal_filter.cc",
         "field_filter.cc",
+        "not_filter.cc",
         "or_filter.cc",
         "partial_filter.cc",
         "true_filter.cc",
@@ -18,6 +19,7 @@ cc_library(
         "and_filter.h",
         "equal_filter.h",
         "field_filter.h",
+        "not_filter.h",
         "or_filter.h",
         "partial_filter.h",
         "true_filter.h",
@@ -86,6 +88,22 @@ cc_test(
 cc_test(
     name = "and_filter_test",
     srcs = ["and_filter_test.cc"],
+    deps = [
+        ":field_filter",
+        "//src/main/cc/wfa/virtual_people/common/field_filter/test:test_cc_proto",
+        "//src/main/proto/wfa/virtual_people/common:field_filter_cc_proto",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
+        "@cross_media_measurement//src/test/cc/testutil:matchers",
+        "@cross_media_measurement//src/test/cc/testutil:status_macros",
+    ],
+)
+
+cc_test(
+    name = "not_filter_test",
+    srcs = ["not_filter_test.cc"],
     deps = [
         ":field_filter",
         "//src/main/cc/wfa/virtual_people/common/field_filter/test:test_cc_proto",

--- a/src/main/cc/wfa/virtual_people/common/field_filter/equal_filter.h
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/equal_filter.h
@@ -30,9 +30,10 @@ class EqualFilter : public FieldFilter {
   // Users should never call EqualFilter::New or any constructor directly.
   //
   // Returns error status if any of the following happens:
-  //   @config.op is not EQUAL.
-  //   @config.name is not set.
-  //   @config.value is not set.
+  // * @config.op is not EQUAL.
+  // * @config.name is not set.
+  // * Any field of the path represented by @config.name is repeated field.
+  // * @config.value is not set.
   //
   // @config.value will be casted to the type of the field represented by
   // @config.name.

--- a/src/main/cc/wfa/virtual_people/common/field_filter/equal_filter_test.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/equal_filter_test.cc
@@ -51,6 +51,32 @@ TEST(EqualFilterTest, TestNoName) {
       StatusIs(absl::StatusCode::kInvalidArgument, ""));
 }
 
+TEST(EqualFilterTest, TestDisallowedRepeated) {
+  FieldFilterProto field_filter_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      name: "a.b.int32_values"
+      op: EQUAL
+      value: "1"
+  )pb", &field_filter_proto));
+  EXPECT_THAT(
+      FieldFilter::New(TestProto().GetDescriptor(),
+                       field_filter_proto).status(),
+      StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+TEST(EqualFilterTest, TestDisallowedRepeatedInThePath) {
+  FieldFilterProto field_filter_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      name: "repeated_proto_a.b.int32_value"
+      op: EQUAL
+      value: "1"
+  )pb", &field_filter_proto));
+  EXPECT_THAT(
+      FieldFilter::New(TestProto().GetDescriptor(),
+                       field_filter_proto).status(),
+      StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
 TEST(EqualFilterTest, TestNoValue) {
   FieldFilterProto field_filter_proto;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(

--- a/src/main/cc/wfa/virtual_people/common/field_filter/field_filter.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/field_filter.cc
@@ -21,6 +21,7 @@
 #include "wfa/measurement/common/macros.h"
 #include "wfa/virtual_people/common/field_filter/and_filter.h"
 #include "wfa/virtual_people/common/field_filter/equal_filter.h"
+#include "wfa/virtual_people/common/field_filter/has_filter.h"
 #include "wfa/virtual_people/common/field_filter/not_filter.h"
 #include "wfa/virtual_people/common/field_filter/or_filter.h"
 #include "wfa/virtual_people/common/field_filter/partial_filter.h"
@@ -34,7 +35,7 @@ absl::StatusOr<std::unique_ptr<FieldFilter>> FieldFilter::New(
     const FieldFilterProto& config) {
   switch (config.op()) {
     case FieldFilterProto::HAS:
-      return absl::UnimplementedError("HAS field filter is not implemented.");
+      return HasFilter::New(descriptor, config);
     case FieldFilterProto::EQUAL:
       return EqualFilter::New(descriptor, config);
     case FieldFilterProto::GT:

--- a/src/main/cc/wfa/virtual_people/common/field_filter/field_filter.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/field_filter.cc
@@ -21,6 +21,7 @@
 #include "wfa/measurement/common/macros.h"
 #include "wfa/virtual_people/common/field_filter/and_filter.h"
 #include "wfa/virtual_people/common/field_filter/equal_filter.h"
+#include "wfa/virtual_people/common/field_filter/or_filter.h"
 #include "wfa/virtual_people/common/field_filter/partial_filter.h"
 #include "wfa/virtual_people/common/field_filter/true_filter.h"
 #include "wfa/virtual_people/common/field_filter/utils/message_filter_util.h"
@@ -45,7 +46,7 @@ absl::StatusOr<std::unique_ptr<FieldFilter>> FieldFilter::New(
       return absl::UnimplementedError(
           "REGEXP field filter is not implemented.");
     case FieldFilterProto::OR:
-      return absl::UnimplementedError("OR field filter is not implemented.");
+      return OrFilter::New(descriptor, config);
     case FieldFilterProto::AND:
       return AndFilter::New(descriptor, config);
     case FieldFilterProto::NOT:

--- a/src/main/cc/wfa/virtual_people/common/field_filter/field_filter.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/field_filter.cc
@@ -21,6 +21,7 @@
 #include "wfa/measurement/common/macros.h"
 #include "wfa/virtual_people/common/field_filter/and_filter.h"
 #include "wfa/virtual_people/common/field_filter/equal_filter.h"
+#include "wfa/virtual_people/common/field_filter/not_filter.h"
 #include "wfa/virtual_people/common/field_filter/or_filter.h"
 #include "wfa/virtual_people/common/field_filter/partial_filter.h"
 #include "wfa/virtual_people/common/field_filter/true_filter.h"
@@ -50,7 +51,7 @@ absl::StatusOr<std::unique_ptr<FieldFilter>> FieldFilter::New(
     case FieldFilterProto::AND:
       return AndFilter::New(descriptor, config);
     case FieldFilterProto::NOT:
-      return absl::UnimplementedError("NOT field filter is not implemented.");
+      return NotFilter::New(descriptor, config);
     case FieldFilterProto::PARTIAL:
       return PartialFilter::New(descriptor, config);
     case FieldFilterProto::TRUE:

--- a/src/main/cc/wfa/virtual_people/common/field_filter/has_filter.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/has_filter.cc
@@ -40,7 +40,7 @@ absl::StatusOr<std::unique_ptr<HasFilter>> HasFilter::New(
 
   ASSIGN_OR_RETURN(
       std::vector<const google::protobuf::FieldDescriptor*> field_descriptors,
-      GetFieldFromProto(descriptor, config.name()));
+      GetFieldFromProto(descriptor, config.name(), /* allow_repeated = */true));
   return absl::make_unique<HasFilter>(std::move(field_descriptors));
 }
 

--- a/src/main/cc/wfa/virtual_people/common/field_filter/has_filter.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/has_filter.cc
@@ -1,0 +1,57 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "wfa/virtual_people/common/field_filter/has_filter.h"
+
+#include "absl/memory/memory.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/message.h"
+#include "src/main/proto/wfa/virtual_people/common/field_filter.pb.h"
+#include "wfa/measurement/common/macros.h"
+#include "wfa/virtual_people/common/field_filter/field_filter.h"
+#include "wfa/virtual_people/common/field_filter/utils/field_util.h"
+
+namespace wfa_virtual_people {
+
+absl::StatusOr<std::unique_ptr<HasFilter>> HasFilter::New(
+    const google::protobuf::Descriptor* descriptor,
+    const FieldFilterProto& config) {
+  if (config.op() != FieldFilterProto::HAS) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Op must be HAS. Input FieldFilterProto: ", config.DebugString()));
+  }
+  if (!config.has_name()) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Name must be set. Input FieldFilterProto: ", config.DebugString()));
+  }
+
+  ASSIGN_OR_RETURN(
+      std::vector<const google::protobuf::FieldDescriptor*> field_descriptors,
+      GetFieldFromProto(descriptor, config.name()));
+  return absl::make_unique<HasFilter>(std::move(field_descriptors));
+}
+
+bool HasFilter::IsMatch(const google::protobuf::Message& message) const {
+  const google::protobuf::Message& parent =
+      GetParentMessageFromProto(message, field_descriptors_);
+  const google::protobuf::FieldDescriptor* field = field_descriptors_.back();
+  if (field->is_repeated()) {
+    return (parent.GetReflection()->FieldSize(parent, field) > 0);
+  }
+  return parent.GetReflection()->HasField(parent, field);
+};
+
+}  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/common/field_filter/has_filter.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/has_filter.cc
@@ -49,7 +49,7 @@ bool HasFilter::IsMatch(const google::protobuf::Message& message) const {
       GetParentMessageFromProto(message, field_descriptors_);
   const google::protobuf::FieldDescriptor* field = field_descriptors_.back();
   if (field->is_repeated()) {
-    return (parent.GetReflection()->FieldSize(parent, field) > 0);
+    return parent.GetReflection()->FieldSize(parent, field) > 0;
   }
   return parent.GetReflection()->HasField(parent, field);
 };

--- a/src/main/cc/wfa/virtual_people/common/field_filter/has_filter.h
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/has_filter.h
@@ -30,8 +30,10 @@ class HasFilter : public FieldFilter {
   // Users should never call HasFilter::New or any constructor directly.
   //
   // Returns error status if any of the following happens:
-  //   @config.op is not HAS.
-  //   @config.name is not set or invalid.
+  // * @config.op is not HAS.
+  // * @config.name is not set or invalid.
+  // * Any field, except the last one, of the path represented by @config.name
+  //   is repeated field.
   static absl::StatusOr<std::unique_ptr<HasFilter>> New(
       const google::protobuf::Descriptor* descriptor,
       const FieldFilterProto& config);
@@ -44,7 +46,7 @@ class HasFilter : public FieldFilter {
   HasFilter& operator=(const HasFilter&) = delete;
 
   // Returns true if any of the following is true
-  // * The field is not repeated, and exists in @message.
+  // * The field is not repeated, and is set in @message.
   // * The field is repeated, and is not empty in @message.
   bool IsMatch(const google::protobuf::Message& message) const override;
 

--- a/src/main/cc/wfa/virtual_people/common/field_filter/has_filter.h
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/has_filter.h
@@ -1,0 +1,57 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WFA_VIRTUAL_PEOPLE_COMMON_FIELD_FILTER_HAS_FILTER_H_
+#define WFA_VIRTUAL_PEOPLE_COMMON_FIELD_FILTER_HAS_FILTER_H_
+
+#include "absl/status/statusor.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/message.h"
+#include "src/main/proto/wfa/virtual_people/common/field_filter.pb.h"
+#include "wfa/virtual_people/common/field_filter/field_filter.h"
+
+namespace wfa_virtual_people {
+
+// The implementation of field filter when op is HAS in @config.
+class HasFilter : public FieldFilter {
+ public:
+  // Always use FieldFilter::New.
+  // Users should never call HasFilter::New or any constructor directly.
+  //
+  // Returns error status if any of the following happens:
+  //   @config.op is not HAS.
+  //   @config.name is not set or invalid.
+  static absl::StatusOr<std::unique_ptr<HasFilter>> New(
+      const google::protobuf::Descriptor* descriptor,
+      const FieldFilterProto& config);
+
+  explicit HasFilter(
+      std::vector<const google::protobuf::FieldDescriptor*>&& field_descriptors
+  ): field_descriptors_(std::move(field_descriptors)) {}
+
+  HasFilter(const HasFilter&) = delete;
+  HasFilter& operator=(const HasFilter&) = delete;
+
+  // Returns true if any of the following is true
+  // * The field is not repeated, and exists in @message.
+  // * The field is repeated, and is not empty in @message.
+  bool IsMatch(const google::protobuf::Message& message) const override;
+
+ private:
+  std::vector<const google::protobuf::FieldDescriptor*> field_descriptors_;
+};
+
+}  // namespace wfa_virtual_people
+
+#endif  // WFA_VIRTUAL_PEOPLE_COMMON_FIELD_FILTER_HAS_FILTER_H_

--- a/src/main/cc/wfa/virtual_people/common/field_filter/has_filter_test.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/has_filter_test.cc
@@ -1,0 +1,113 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "google/protobuf/text_format.h"
+#include "gtest/gtest.h"
+#include "src/main/cc/wfa/virtual_people/common/field_filter/test/test.pb.h"
+#include "src/main/proto/wfa/virtual_people/common/field_filter.pb.h"
+#include "src/test/cc/testutil/matchers.h"
+#include "src/test/cc/testutil/status_macros.h"
+#include "wfa/virtual_people/common/field_filter/field_filter.h"
+
+namespace wfa_virtual_people {
+namespace {
+
+using ::wfa::StatusIs;
+using ::wfa_virtual_people::test::TestProto;
+
+// This function is required to test the FieldFilter still works when the
+// FieldFilterProto is out of scope.
+absl::StatusOr<std::unique_ptr<FieldFilter>> FilterFromProtoText(
+    absl::string_view proto_text) {
+  FieldFilterProto field_filter_proto;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      std::string(proto_text), &field_filter_proto));
+  return FieldFilter::New(TestProto().GetDescriptor(), field_filter_proto);
+}
+
+TEST(HasFilterTest, TestNoName) {
+  FieldFilterProto field_filter_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      op: HAS
+  )pb", &field_filter_proto));
+  EXPECT_THAT(
+      FieldFilter::New(TestProto().GetDescriptor(),
+                       field_filter_proto).status(),
+      StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+TEST(HasFilterTest, TestInvalidName) {
+  FieldFilterProto field_filter_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      name: "a.b.invalid_field"
+      op: HAS
+  )pb", &field_filter_proto));
+  EXPECT_THAT(
+      FieldFilter::New(TestProto().GetDescriptor(),
+                       field_filter_proto).status(),
+      StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+TEST(HasFilterTest, TestNonRepeated) {
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<FieldFilter> field_filter,
+      FilterFromProtoText(R"pb(
+          name: "a.b.int32_value"
+          op: HAS
+      )pb"));
+
+  TestProto test_proto_1;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      a {
+        b {
+          int32_value: 1
+        }
+      }
+  )pb", &test_proto_1));
+  EXPECT_TRUE(field_filter->IsMatch(test_proto_1));
+  TestProto test_proto_2;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      a {
+        b {
+          int64_value: 1
+        }
+      }
+  )pb", &test_proto_2));
+  EXPECT_FALSE(field_filter->IsMatch(test_proto_2));
+  TestProto test_proto_3;
+  EXPECT_FALSE(field_filter->IsMatch(test_proto_3));
+}
+
+TEST(HasFilterTest, TestRepeated) {
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<FieldFilter> field_filter,
+      FilterFromProtoText(R"pb(
+          name: "int32_values"
+          op: HAS
+      )pb"));
+
+  TestProto test_proto_1;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      int32_values: 1
+  )pb", &test_proto_1));
+  EXPECT_TRUE(field_filter->IsMatch(test_proto_1));
+  TestProto test_proto_2;
+  EXPECT_FALSE(field_filter->IsMatch(test_proto_2));
+}
+
+}  // namespace
+}  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/common/field_filter/not_filter.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/not_filter.cc
@@ -1,0 +1,54 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "wfa/virtual_people/common/field_filter/not_filter.h"
+
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/message.h"
+#include "src/main/proto/wfa/virtual_people/common/field_filter.pb.h"
+#include "wfa/measurement/common/macros.h"
+#include "wfa/virtual_people/common/field_filter/field_filter.h"
+
+namespace wfa_virtual_people {
+
+absl::StatusOr<std::unique_ptr<NotFilter>> NotFilter::New(
+    const google::protobuf::Descriptor* descriptor,
+    const FieldFilterProto& config) {
+  if (config.op() != FieldFilterProto::NOT) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Op must be NOT. Input FieldFilterProto: ",
+        config.DebugString()));
+  }
+  if (config.sub_filters_size() == 0) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "sub_filters must be set when op is NOT. Input FieldFilterProto: ",
+        config.DebugString()));
+  }
+
+  FieldFilterProto and_filter_config = config;
+  and_filter_config.set_op(FieldFilterProto::AND);
+  ASSIGN_OR_RETURN(
+      std::unique_ptr<FieldFilter> and_filter,
+      FieldFilter::New(descriptor, and_filter_config));
+
+  return absl::make_unique<NotFilter>(std::move(and_filter));
+}
+
+bool NotFilter::IsMatch(const google::protobuf::Message& message) const {
+  return !and_filter_->IsMatch(message);
+}
+
+}  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/common/field_filter/not_filter.h
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/not_filter.h
@@ -1,0 +1,59 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WFA_VIRTUAL_PEOPLE_COMMON_FIELD_FILTER_NOT_FILTER_H_
+#define WFA_VIRTUAL_PEOPLE_COMMON_FIELD_FILTER_NOT_FILTER_H_
+
+#include "absl/status/statusor.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/message.h"
+#include "src/main/proto/wfa/virtual_people/common/field_filter.pb.h"
+#include "wfa/virtual_people/common/field_filter/field_filter.h"
+
+namespace wfa_virtual_people {
+
+// The implementation of field filter when op is NOT in @config.
+class NotFilter : public FieldFilter {
+ public:
+  // Always use FieldFilter::New.
+  // Users should never call NotFilter::New or any constructor directly.
+  //
+  // Returns error status if any of the following happens:
+  //    @config.op is not NOT.
+  //    @config.sub_filters is empty.
+  //    Any of @config.sub_filters is invalid to create a FieldFilter.
+  static absl::StatusOr<std::unique_ptr<NotFilter>> New(
+      const google::protobuf::Descriptor* descriptor,
+      const FieldFilterProto& config);
+
+  explicit NotFilter(
+      std::unique_ptr<FieldFilter> and_filter):
+      and_filter_(std::move(and_filter)) {}
+
+  NotFilter(const NotFilter&) = delete;
+  NotFilter& operator=(const NotFilter&) = delete;
+
+  // Returns false when all the sub_filters pass. Otherwise, returns true.
+  bool IsMatch(const google::protobuf::Message& message) const override;
+
+ private:
+  // A field filter represents the AND of all the sub_filters.
+  // The output of this NotFilter should be the reverse of the output of 
+  // and_filter_.
+  std::unique_ptr<FieldFilter> and_filter_;
+};
+
+}  // namespace wfa_virtual_people
+
+#endif  // WFA_VIRTUAL_PEOPLE_COMMON_FIELD_FILTER_NOT_FILTER_H_

--- a/src/main/cc/wfa/virtual_people/common/field_filter/not_filter.h
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/not_filter.h
@@ -44,12 +44,13 @@ class NotFilter : public FieldFilter {
   NotFilter(const NotFilter&) = delete;
   NotFilter& operator=(const NotFilter&) = delete;
 
-  // Returns false when all the sub_filters pass. Otherwise, returns true.
+  // Returns false when all the @config.sub_filters pass.
+  // Otherwise, returns true.
   bool IsMatch(const google::protobuf::Message& message) const override;
 
  private:
   // A field filter represents the AND of all the sub_filters.
-  // The output of this NotFilter should be the reverse of the output of 
+  // The output of this NotFilter should be the reverse of the output of
   // and_filter_.
   std::unique_ptr<FieldFilter> and_filter_;
 };

--- a/src/main/cc/wfa/virtual_people/common/field_filter/not_filter_test.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/not_filter_test.cc
@@ -1,0 +1,104 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "google/protobuf/text_format.h"
+#include "gtest/gtest.h"
+#include "src/main/cc/wfa/virtual_people/common/field_filter/test/test.pb.h"
+#include "src/main/proto/wfa/virtual_people/common/field_filter.pb.h"
+#include "src/test/cc/testutil/matchers.h"
+#include "src/test/cc/testutil/status_macros.h"
+#include "wfa/virtual_people/common/field_filter/field_filter.h"
+
+namespace wfa_virtual_people {
+namespace {
+
+using ::wfa::StatusIs;
+using ::wfa_virtual_people::test::TestProto;
+
+TEST(NotFilterTest, TestNoSubFilters) {
+  FieldFilterProto field_filter_proto;
+  field_filter_proto.set_op(FieldFilterProto::NOT);
+  EXPECT_THAT(
+      FieldFilter::New(TestProto().GetDescriptor(),
+                       field_filter_proto).status(),
+      StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+TEST(NotFilterTest, TestNotMatch) {
+  FieldFilterProto field_filter_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      op: NOT
+      sub_filters {
+        name: "a.b.int32_value"
+        op: EQUAL
+        value: "1"
+      }
+      sub_filters {
+        name: "a.b.int64_value"
+        op: EQUAL
+        value: "1"
+      }
+  )pb", &field_filter_proto));
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<FieldFilter> field_filter,
+      FieldFilter::New(TestProto().GetDescriptor(), field_filter_proto));
+
+  TestProto test_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      a {
+        b {
+          int32_value: 1
+          int64_value: 1
+        }
+      }
+  )pb", &test_proto));
+  EXPECT_FALSE(field_filter->IsMatch(test_proto));
+}
+
+TEST(NotFilterTest, TestMatch) {
+  FieldFilterProto field_filter_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      op: NOT
+      sub_filters {
+        name: "a.b.int32_value"
+        op: EQUAL
+        value: "1"
+      }
+      sub_filters {
+        name: "a.b.int64_value"
+        op: EQUAL
+        value: "1"
+      }
+  )pb", &field_filter_proto));
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<FieldFilter> field_filter,
+      FieldFilter::New(TestProto().GetDescriptor(), field_filter_proto));
+
+  TestProto test_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      a {
+        b {
+          int32_value: 1
+          int64_value: 2
+        }
+      }
+  )pb", &test_proto));
+  EXPECT_TRUE(field_filter->IsMatch(test_proto));
+}
+
+}  // namespace
+}  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/common/field_filter/not_filter_test.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/not_filter_test.cc
@@ -88,7 +88,7 @@ TEST(NotFilterTest, TestMatch) {
       std::unique_ptr<FieldFilter> field_filter,
       FieldFilter::New(TestProto().GetDescriptor(), field_filter_proto));
 
-  TestProto test_proto;
+  TestProto test_proto_1;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
       a {
         b {
@@ -96,8 +96,18 @@ TEST(NotFilterTest, TestMatch) {
           int64_value: 2
         }
       }
-  )pb", &test_proto));
-  EXPECT_TRUE(field_filter->IsMatch(test_proto));
+  )pb", &test_proto_1));
+  EXPECT_TRUE(field_filter->IsMatch(test_proto_1));
+
+  TestProto test_proto_2;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      a {
+        b {
+          int32_value: 1
+        }
+      }
+  )pb", &test_proto_2));
+  EXPECT_TRUE(field_filter->IsMatch(test_proto_2));
 }
 
 }  // namespace

--- a/src/main/cc/wfa/virtual_people/common/field_filter/not_filter_test.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/not_filter_test.cc
@@ -108,6 +108,20 @@ TEST(NotFilterTest, TestMatch) {
       }
   )pb", &test_proto_2));
   EXPECT_TRUE(field_filter->IsMatch(test_proto_2));
+
+  TestProto test_proto_3;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      a {
+        b {
+          int32_value: 2
+          int64_value: 2
+        }
+      }
+  )pb", &test_proto_3));
+  EXPECT_TRUE(field_filter->IsMatch(test_proto_3));
+
+  TestProto test_proto_4;
+  EXPECT_TRUE(field_filter->IsMatch(test_proto_4));
 }
 
 }  // namespace

--- a/src/main/cc/wfa/virtual_people/common/field_filter/or_filter.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/or_filter.cc
@@ -1,0 +1,61 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "wfa/virtual_people/common/field_filter/or_filter.h"
+
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/message.h"
+#include "src/main/proto/wfa/virtual_people/common/field_filter.pb.h"
+#include "wfa/measurement/common/macros.h"
+#include "wfa/virtual_people/common/field_filter/field_filter.h"
+
+namespace wfa_virtual_people {
+
+absl::StatusOr<std::unique_ptr<OrFilter>> OrFilter::New(
+    const google::protobuf::Descriptor* descriptor,
+    const FieldFilterProto& config) {
+  if (config.op() != FieldFilterProto::OR) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Op must be OR. Input FieldFilterProto: ",
+        config.DebugString()));
+  }
+  if (config.sub_filters_size() == 0) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "sub_filters must be set when op is OR. Input FieldFilterProto: ",
+        config.DebugString()));
+  }
+
+  std::vector<std::unique_ptr<FieldFilter>> sub_filters;
+  for (const FieldFilterProto& sub_filter_proto : config.sub_filters()) {
+    sub_filters.emplace_back();
+    ASSIGN_OR_RETURN(
+        sub_filters.back(),
+        FieldFilter::New(descriptor, sub_filter_proto));
+  }
+
+  return absl::make_unique<OrFilter>(std::move(sub_filters));
+}
+
+bool OrFilter::IsMatch(const google::protobuf::Message& message) const {
+  for (auto& filter : sub_filters_) {
+    if (filter->IsMatch(message)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/common/field_filter/or_filter.h
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/or_filter.h
@@ -1,0 +1,56 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WFA_VIRTUAL_PEOPLE_COMMON_FIELD_FILTER_OR_FILTER_H_
+#define WFA_VIRTUAL_PEOPLE_COMMON_FIELD_FILTER_OR_FILTER_H_
+
+#include "absl/status/statusor.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/message.h"
+#include "src/main/proto/wfa/virtual_people/common/field_filter.pb.h"
+#include "wfa/virtual_people/common/field_filter/field_filter.h"
+
+namespace wfa_virtual_people {
+
+// The implementation of field filter when op is OR in @config.
+class OrFilter : public FieldFilter {
+ public:
+  // Always use FieldFilter::New.
+  // Users should never call OrFilter::New or any constructor directly.
+  //
+  // Returns error status if any of the following happens:
+  //    @config.op is not OR.
+  //    @config.sub_filters is empty.
+  //    Any of @config.sub_filters is invalid to create a FieldFilter.
+  static absl::StatusOr<std::unique_ptr<OrFilter>> New(
+      const google::protobuf::Descriptor* descriptor,
+      const FieldFilterProto& config);
+
+  explicit OrFilter(
+      std::vector<std::unique_ptr<FieldFilter>>&& sub_filters):
+      sub_filters_(std::move(sub_filters)) {}
+
+  OrFilter(const OrFilter&) = delete;
+  OrFilter& operator=(const OrFilter&) = delete;
+
+  // Returns true when any of the sub_filters passes. Otherwise, returns false.
+  bool IsMatch(const google::protobuf::Message& message) const override;
+
+ private:
+  std::vector<std::unique_ptr<FieldFilter>> sub_filters_;
+};
+
+}  // namespace wfa_virtual_people
+
+#endif  // WFA_VIRTUAL_PEOPLE_COMMON_FIELD_FILTER_OR_FILTER_H_

--- a/src/main/cc/wfa/virtual_people/common/field_filter/or_filter_test.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/or_filter_test.cc
@@ -117,6 +117,9 @@ TEST(OrFilterTest, TestNotMatch) {
       }
   )pb", &test_proto_2));
   EXPECT_FALSE(field_filter->IsMatch(test_proto_2));
+
+  TestProto test_proto_3;
+  EXPECT_FALSE(field_filter->IsMatch(test_proto_3));
 }
 
 }  // namespace

--- a/src/main/cc/wfa/virtual_people/common/field_filter/or_filter_test.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/or_filter_test.cc
@@ -57,7 +57,7 @@ TEST(OrFilterTest, TestMatch) {
       std::unique_ptr<FieldFilter> field_filter,
       FieldFilter::New(TestProto().GetDescriptor(), field_filter_proto));
 
-  TestProto test_proto;
+  TestProto test_proto_1;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
       a {
         b {
@@ -65,8 +65,18 @@ TEST(OrFilterTest, TestMatch) {
           int64_value: 1
         }
       }
-  )pb", &test_proto));
-  EXPECT_TRUE(field_filter->IsMatch(test_proto));
+  )pb", &test_proto_1));
+  EXPECT_TRUE(field_filter->IsMatch(test_proto_1));
+
+  TestProto test_proto_2;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      a {
+        b {
+          int64_value: 1
+        }
+      }
+  )pb", &test_proto_2));
+  EXPECT_TRUE(field_filter->IsMatch(test_proto_2));
 }
 
 TEST(OrFilterTest, TestNotMatch) {
@@ -88,7 +98,7 @@ TEST(OrFilterTest, TestNotMatch) {
       std::unique_ptr<FieldFilter> field_filter,
       FieldFilter::New(TestProto().GetDescriptor(), field_filter_proto));
 
-  TestProto test_proto;
+  TestProto test_proto_1;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
       a {
         b {
@@ -96,8 +106,17 @@ TEST(OrFilterTest, TestNotMatch) {
           int64_value: 2
         }
       }
-  )pb", &test_proto));
-  EXPECT_FALSE(field_filter->IsMatch(test_proto));
+  )pb", &test_proto_1));
+  EXPECT_FALSE(field_filter->IsMatch(test_proto_1));
+
+  TestProto test_proto_2;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      a {
+        b {
+        }
+      }
+  )pb", &test_proto_2));
+  EXPECT_FALSE(field_filter->IsMatch(test_proto_2));
 }
 
 }  // namespace

--- a/src/main/cc/wfa/virtual_people/common/field_filter/or_filter_test.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/or_filter_test.cc
@@ -1,0 +1,104 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "google/protobuf/text_format.h"
+#include "gtest/gtest.h"
+#include "src/main/cc/wfa/virtual_people/common/field_filter/test/test.pb.h"
+#include "src/main/proto/wfa/virtual_people/common/field_filter.pb.h"
+#include "src/test/cc/testutil/matchers.h"
+#include "src/test/cc/testutil/status_macros.h"
+#include "wfa/virtual_people/common/field_filter/field_filter.h"
+
+namespace wfa_virtual_people {
+namespace {
+
+using ::wfa::StatusIs;
+using ::wfa_virtual_people::test::TestProto;
+
+TEST(OrFilterTest, TestNoSubFilters) {
+  FieldFilterProto field_filter_proto;
+  field_filter_proto.set_op(FieldFilterProto::OR);
+  EXPECT_THAT(
+      FieldFilter::New(TestProto().GetDescriptor(),
+                       field_filter_proto).status(),
+      StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+TEST(OrFilterTest, TestMatch) {
+  FieldFilterProto field_filter_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      op: OR
+      sub_filters {
+        name: "a.b.int32_value"
+        op: EQUAL
+        value: "1"
+      }
+      sub_filters {
+        name: "a.b.int64_value"
+        op: EQUAL
+        value: "1"
+      }
+  )pb", &field_filter_proto));
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<FieldFilter> field_filter,
+      FieldFilter::New(TestProto().GetDescriptor(), field_filter_proto));
+
+  TestProto test_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      a {
+        b {
+          int32_value: 2
+          int64_value: 1
+        }
+      }
+  )pb", &test_proto));
+  EXPECT_TRUE(field_filter->IsMatch(test_proto));
+}
+
+TEST(OrFilterTest, TestNotMatch) {
+  FieldFilterProto field_filter_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      op: OR
+      sub_filters {
+        name: "a.b.int32_value"
+        op: EQUAL
+        value: "1"
+      }
+      sub_filters {
+        name: "a.b.int64_value"
+        op: EQUAL
+        value: "1"
+      }
+  )pb", &field_filter_proto));
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<FieldFilter> field_filter,
+      FieldFilter::New(TestProto().GetDescriptor(), field_filter_proto));
+
+  TestProto test_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      a {
+        b {
+          int32_value: 2
+          int64_value: 2
+        }
+      }
+  )pb", &test_proto));
+  EXPECT_FALSE(field_filter->IsMatch(test_proto));
+}
+
+}  // namespace
+}  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/common/field_filter/partial_filter.h
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/partial_filter.h
@@ -30,11 +30,12 @@ class PartialFilter : public FieldFilter {
   // Users should never call PartialFilter::New or any constructor directly.
   //
   // Returns error status when any of the following happens:
-  //   @config.op is not PARTIAL.
-  //   @config.name is not set.
-  //   @config.name does not refer to a message type.
-  //   @config.sub_filters is empty.
-  //   Any of @config.sub_filters is invalid to create a FieldFilter.
+  // * @config.op is not PARTIAL.
+  // * @config.name is not set.
+  // * @config.name does not refer to a message type.
+  // * Any field of the path represented by @config.name is repeated field.
+  // * @config.sub_filters is empty.
+  // * Any of @config.sub_filters is invalid to create a FieldFilter.
   static absl::StatusOr<std::unique_ptr<PartialFilter>> New(
       const google::protobuf::Descriptor* descriptor,
       const FieldFilterProto& config);

--- a/src/main/cc/wfa/virtual_people/common/field_filter/partial_filter_test.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/partial_filter_test.cc
@@ -50,6 +50,40 @@ TEST(PartialFilterTest, TestNoName) {
       StatusIs(absl::StatusCode::kInvalidArgument, ""));
 }
 
+TEST(PartialFilterTest, TestDisallowedRepeated) {
+  FieldFilterProto field_filter_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      name: "a.b"
+      op: PARTIAL
+      sub_filters {
+        name: "int32_values"
+        op: EQUAL
+        value: "1"
+      }
+  )pb", &field_filter_proto));
+  EXPECT_THAT(
+      FieldFilter::New(TestProto().GetDescriptor(),
+                       field_filter_proto).status(),
+      StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+TEST(PartialFilterTest, TestDisallowedRepeatedInThePath) {
+  FieldFilterProto field_filter_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
+      name: "repeated_proto_a.b"
+      op: PARTIAL
+      sub_filters {
+        name: "int32_value"
+        op: EQUAL
+        value: "1"
+      }
+  )pb", &field_filter_proto));
+  EXPECT_THAT(
+      FieldFilter::New(TestProto().GetDescriptor(),
+                       field_filter_proto).status(),
+      StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
 TEST(PartialFilterTest, TestNoSubFilters) {
   FieldFilterProto field_filter_proto;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(

--- a/src/main/cc/wfa/virtual_people/common/field_filter/test/test.proto
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/test/test.proto
@@ -21,6 +21,8 @@ message TestProto {
   optional TestProtoA a = 1;
 
   repeated int32 int32_values = 2;
+
+  repeated TestProtoA repeated_proto_a = 3;
 }
 
 message TestProtoA {
@@ -42,4 +44,6 @@ message TestProtoB {
   optional bool bool_value = 7;
   optional TestEnum enum_value = 8;
   optional string string_value = 9;
+
+  repeated int32 int32_values = 10;
 }

--- a/src/main/cc/wfa/virtual_people/common/field_filter/utils/BUILD.bazel
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/utils/BUILD.bazel
@@ -29,6 +29,7 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "@com_google_protobuf//:protobuf",
         "@cross_media_measurement//src/test/cc/testutil:matchers",
+        "@cross_media_measurement//src/test/cc/testutil:status_macros",
     ],
 )
 

--- a/src/main/cc/wfa/virtual_people/common/field_filter/utils/field_util.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/utils/field_util.cc
@@ -27,7 +27,8 @@ namespace wfa_virtual_people {
 absl::StatusOr<std::vector<const google::protobuf::FieldDescriptor*>>
 GetFieldFromProto(
     const google::protobuf::Descriptor* descriptor,
-    absl::string_view full_field_name) {
+    absl::string_view full_field_name,
+    bool allow_repeated) {
   std::vector<const google::protobuf::FieldDescriptor*> field_descriptors;
   std::vector<std::string> field_names = absl::StrSplit(full_field_name, ".");
   for (const std::string& field_name : field_names) {
@@ -44,6 +45,17 @@ GetFieldFromProto(
     field_descriptors.emplace_back(field_descriptor);
     descriptor = field_descriptor->message_type();
   }
+  for (auto it = field_descriptors.begin(), j = field_descriptors.end() - 1;
+       it != j; it++) {
+    if ((*it)->is_repeated()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Repeated field is not allowed in the path: ", full_field_name));
+    }
+  }
+  if (!allow_repeated && field_descriptors.back()->is_repeated()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Repeated field is not allowed in the path: ", full_field_name));
+  }
   return field_descriptors;
 }
 
@@ -59,6 +71,7 @@ const google::protobuf::Message& GetParentMessageFromProto(
   }
   return *tmp_message;
 }
+
 template <typename ValueType>
 ValueType GetImmediateValueFromProto(
     const google::protobuf::Message& message,

--- a/src/main/cc/wfa/virtual_people/common/field_filter/utils/field_util.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/utils/field_util.cc
@@ -46,7 +46,7 @@ GetFieldFromProto(
     descriptor = field_descriptor->message_type();
   }
   for (auto it = field_descriptors.begin(), j = field_descriptors.end() - 1;
-       it != j; it++) {
+       it != j; ++it) {
     if ((*it)->is_repeated()) {
       return absl::InvalidArgumentError(absl::StrCat(
           "Repeated field is not allowed in the path: ", full_field_name));
@@ -65,7 +65,7 @@ const google::protobuf::Message& GetParentMessageFromProto(
         field_descriptors) {
   const google::protobuf::Message* tmp_message = &message;
   for (auto it = field_descriptors.begin(), j = field_descriptors.end() - 1;
-       it != j; it++) {
+       it != j; ++it) {
     tmp_message = &(tmp_message->GetReflection()->GetMessage(*tmp_message,
                                                              *it));
   }

--- a/src/main/cc/wfa/virtual_people/common/field_filter/utils/field_util.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/utils/field_util.cc
@@ -47,6 +47,18 @@ GetFieldFromProto(
   return field_descriptors;
 }
 
+const google::protobuf::Message& GetParentMessageFromProto(
+    const google::protobuf::Message& message,
+    const std::vector<const google::protobuf::FieldDescriptor*>&
+        field_descriptors) {
+  const google::protobuf::Message* tmp_message = &message;
+  for (auto it = field_descriptors.begin(), j = field_descriptors.end() - 1;
+       it != j; it++) {
+    tmp_message = &(tmp_message->GetReflection()->GetMessage(*tmp_message,
+                                                             *it));
+  }
+  return *tmp_message;
+}
 template <typename ValueType>
 ValueType GetImmediateValueFromProto(
     const google::protobuf::Message& message,

--- a/src/main/cc/wfa/virtual_people/common/field_filter/utils/field_util.h
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/utils/field_util.h
@@ -40,8 +40,10 @@ GetFieldFromProto(
     absl::string_view full_field_name,
     bool allow_repeated = false);
 
-// Get the parent message of the field represented by @field_descriptors from
+// Gets the parent message of the field represented by @field_descriptors from
 // the @message.
+//
+// Unset parent message is equivalent to an empty message.
 //
 // All elements except the last one in @field_descriptors must refer to a
 // protobuf Message.
@@ -73,8 +75,10 @@ const google::protobuf::Message& GetParentMessageFromProto(
     const std::vector<const google::protobuf::FieldDescriptor*>&
         field_descriptors);
 
-// Get the value from the @message, with field name represented by
+// Gets the value from the @message, with field name represented by
 // @field_descriptor.
+//
+// When called with unset field, returns default value.
 //
 // The field must be an immediate field of @message.
 // The corresponding C++ type of the field must be @ValueType.
@@ -83,8 +87,10 @@ ValueType GetImmediateValueFromProto(
     const google::protobuf::Message& message,
     const google::protobuf::FieldDescriptor* field_descriptor);
 
-// Get the value from the @message, with field path represented by
+// Gets the value from the @message, with field path represented by
 // @field_descriptors.
+//
+// When called with unset field, returns default value.
 //
 // All elements except the last one in @field_descriptors must refer to a
 // protobuf Message. The last one in @field_descriptors must refer to a field

--- a/src/main/cc/wfa/virtual_people/common/field_filter/utils/field_util.h
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/utils/field_util.h
@@ -27,12 +27,18 @@ namespace wfa_virtual_people {
 //
 // @full_field_name is separated by ".".
 //
+// If @allow_repeated is true, only the last field in the path represented by
+// @full_field_name is allowed to be a repeated field.
+// If @allow_repeated is false, no repeated field is allowed in the path.
+// Returns error status if any disallowed repeated field exists.
+//
 // The returned FieldDescriptors is in the order of the field name to access the
 // nested field.
 absl::StatusOr<std::vector<const google::protobuf::FieldDescriptor*>>
 GetFieldFromProto(
     const google::protobuf::Descriptor* descriptor,
-    absl::string_view full_field_name);
+    absl::string_view full_field_name,
+    bool allow_repeated = false);
 
 // Get the parent message of the field represented by @field_descriptors from
 // the @message.

--- a/src/main/cc/wfa/virtual_people/common/field_filter/utils/field_util_test.cc
+++ b/src/main/cc/wfa/virtual_people/common/field_filter/utils/field_util_test.cc
@@ -127,6 +127,67 @@ TEST(GetFieldFromProtoTest, GetFieldAndValue) {
       EqualsProto(test_proto_2.a().b()));
 }
 
+TEST(GetFieldFromProtoTest, GetValueForUnsetField) {
+  TestProto test_proto;
+  // Test int32.
+  absl::StatusOr<std::vector<const google::protobuf::FieldDescriptor*>>
+        field_descriptors =
+        GetFieldFromProto(TestProto().GetDescriptor(), "a.b.int32_value");
+  EXPECT_THAT(field_descriptors, IsOk());
+  EXPECT_EQ(GetValueFromProto<int32_t>(test_proto, *field_descriptors), 0);
+  // Test int64.
+  field_descriptors =
+      GetFieldFromProto(TestProto().GetDescriptor(), "a.b.int64_value");
+  EXPECT_THAT(field_descriptors, IsOk());
+  EXPECT_EQ(GetValueFromProto<int64_t>(test_proto, *field_descriptors), 0);
+  // Test uint32.
+  field_descriptors =
+      GetFieldFromProto(TestProto().GetDescriptor(), "a.b.uint32_value");
+  EXPECT_THAT(field_descriptors, IsOk());
+  EXPECT_EQ(GetValueFromProto<uint32_t>(test_proto, *field_descriptors), 0);
+  // Test uint64.
+  field_descriptors =
+      GetFieldFromProto(TestProto().GetDescriptor(), "a.b.uint64_value");
+  EXPECT_THAT(field_descriptors, IsOk());
+  EXPECT_EQ(GetValueFromProto<uint64_t>(test_proto, *field_descriptors), 0);
+  // Test float.
+  field_descriptors =
+      GetFieldFromProto(TestProto().GetDescriptor(), "a.b.float_value");
+  EXPECT_THAT(field_descriptors, IsOk());
+  EXPECT_EQ(GetValueFromProto<float>(test_proto, *field_descriptors), 0);
+  // Test double.
+  field_descriptors =
+      GetFieldFromProto(TestProto().GetDescriptor(), "a.b.double_value");
+  EXPECT_THAT(field_descriptors, IsOk());
+  EXPECT_EQ(GetValueFromProto<double>(test_proto, *field_descriptors), 0);
+  // Test bool.
+  field_descriptors =
+      GetFieldFromProto(TestProto().GetDescriptor(), "a.b.bool_value");
+  EXPECT_THAT(field_descriptors, IsOk());
+  EXPECT_FALSE(GetValueFromProto<bool>(test_proto, *field_descriptors));
+  // Test enum.
+  field_descriptors =
+      GetFieldFromProto(TestProto().GetDescriptor(), "a.b.enum_value");
+  EXPECT_THAT(field_descriptors, IsOk());
+  EXPECT_EQ(
+      GetValueFromProto<const google::protobuf::EnumValueDescriptor*>(
+          test_proto, *field_descriptors)->number(), 0);
+  // Test string.
+  field_descriptors =
+      GetFieldFromProto(TestProto().GetDescriptor(), "a.b.string_value");
+  EXPECT_THAT(field_descriptors, IsOk());
+  EXPECT_EQ(
+      GetValueFromProto<const std::string&>(test_proto, *field_descriptors),
+      "");
+  // Test Message.
+  field_descriptors = GetFieldFromProto(TestProto().GetDescriptor(), "a.b");
+  EXPECT_THAT(field_descriptors, IsOk());
+  EXPECT_THAT(
+      GetValueFromProto<const google::protobuf::Message&>(
+          test_proto, *field_descriptors),
+      EqualsProto(test_proto.a().b()));
+}
+
 TEST(GetFieldFromProtoTest, InvalidFieldName) {
   TestProto test_proto;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
@@ -234,6 +295,17 @@ TEST(GetFieldFromProtoTest, TestAllowRepeatedAndGetParentMessage) {
         }
       }
   )pb", &test_proto));
+  EXPECT_THAT(
+      GetParentMessageFromProto(test_proto, field_descriptors),
+      EqualsProto(test_proto.a().b()));
+}
+
+TEST(GetFieldFromProtoTest, TestGetParentMessageParentNotSet) {
+  ASSERT_OK_AND_ASSIGN(
+      std::vector<const google::protobuf::FieldDescriptor*> field_descriptors,
+      GetFieldFromProto(TestProto().GetDescriptor(), "a.b.int32_value"));
+
+  TestProto test_proto;
   EXPECT_THAT(
       GetParentMessageFromProto(test_proto, field_descriptors),
       EqualsProto(test_proto.a().b()));


### PR DESCRIPTION
Implement FieldFilterProto with op as OR.
Implement FieldFilterProto with op as NOT.
Implement FieldFilterProto with op as HAS.
Handles repeated fields in field filters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/virtual-people-common/12)
<!-- Reviewable:end -->
