### PR TITLE
Allow multiple quantum labels and classic label to exist together.

### DIFF
--- a/src/main/proto/wfa/virtual_people/common/label.proto
+++ b/src/main/proto/wfa/virtual_people/common/label.proto
@@ -42,13 +42,11 @@ message QuantumLabel {
 }
 
 // Represents a list of quantum labels, each of which is for an independent
-// attribute (or multiple attributes).
+// attribute.
 // When collapsed, each quantum label is collapsed independently, and the
 // outputs are merged into single PersonLabelAttributes.
-// The label field represents the attributes that do not need to be collapsed.
 message IndependentQuantumLabels {
   repeated QuantumLabel quantum_labels = 1;
-  PersonLabelAttributes label = 2;
 }
 
 // Represents a single virtual person.
@@ -60,7 +58,7 @@ message VirtualPersonActivity {
   oneof person_label {
     // Quantum label. This is only for debugging purposes.
     // It will be collapsed before the model populates LabelerOutput.
-    IndependentQuantumLabels quantum_labels = 2;
+    QuantumLabel quantum_label = 2;
 
     // Person attributes.
     // Could be the result of the collapse of quantum_label.

--- a/src/main/proto/wfa/virtual_people/common/model.proto
+++ b/src/main/proto/wfa/virtual_people/common/model.proto
@@ -319,8 +319,10 @@ message LabelerEvent {
   // use different fields.
   optional int32 multiplicity_person_index = 11;
 
-  // Quantum labels. Will be collapsed before the model populates LabelerOutput.
-  // Can also represent classic label when only the quantum_labels.label field
-  // is set.
+  // Quantum labels. Will be collapsed and merged with label below before the
+  // model populates LabelerOutput.
   optional IndependentQuantumLabels quantum_labels = 12;
+
+  // Classic label for person attributes.
+  optional PersonLabelAttributes label = 13;
 }


### PR DESCRIPTION
For different attributes, we may have independent quantum label/classic label.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/virtual-people-common/26)
<!-- Reviewable:end -->
