### PR TITLE
Update virtual_person_id type to uint64.

### DIFF
--- a/src/main/proto/wfa/virtual_people/common/label.proto
+++ b/src/main/proto/wfa/virtual_people/common/label.proto
@@ -56,7 +56,7 @@ message IndependentQuantumLabels {
 message VirtualPersonActivity {
   // If virtual_person_id is not set, then this is only for counting
   // impressions by labels, and can be ignored for reach purpose.
-  optional int64 virtual_person_id = 1;
+  optional uint64 virtual_person_id = 1;
 
   oneof person_label {
     // Quantum label. This is only for debugging purposes.


### PR DESCRIPTION
Currently the population_offset and total_population in VirtualPersonPool are uint64, while virtual_person_id in VirtualPersonActivity is int64. This could cause an issue when the range covered by virtual person pools is out of range of int64.

Update virtual_person_id type to uint64.
This is a safe change per https://developers.google.com/protocol-buffers/docs/proto#updating

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/virtual-people-common/56)
<!-- Reviewable:end -->
