### PR TITLE
Add a space for event collections in the labeler input.

### DIFF
--- a/src/main/proto/wfa/virtual_people/common/event.proto
+++ b/src/main/proto/wfa/virtual_people/common/event.proto
@@ -67,6 +67,15 @@ message UserInfo {
   optional uint64 user_id_fingerprint = 6;
 }
 
+// Represents information about the parent event that is not used in labeling or
+// measurement. These are not intended to be unique across all EDPs.
+message TrafficInfo {
+  // Identifies a collection of events. A model provider can use this to group
+  // events during VID model training. This could be something like a campaign
+  // id.
+  optional string event_collection_id = 1;
+}
+
 // Represents info for all user ids associated with a specific event.
 message ProfileInfo {
   // Information for email id.
@@ -126,6 +135,10 @@ message LabelerInput {
   // Device type string. Computed from user agent string using a library
   // function.
   optional string device_type = 6;
+
+  // Event information not intended to be used during labeling or in the
+  // measurement system.
+  optional TrafficInfo traffic_info = 7;
 }
 
 // LogEvent contains all attributes in LabelerInput, as well as other


### PR DESCRIPTION
These can be data provider campaign ids, some meta identifier, etc. Intended to identify a specific set of events that the model provider knows for model building.

Specifically requested as a way to map consented campaign ids to events in panel exchange, but if there's a better spot for this I'm happy to move it.