### PR TITLE
Add RankedPopulationNode proto for memoized VID assignment

### DIFF
--- a/src/main/proto/wfa/virtual_people/common/event.proto
+++ b/src/main/proto/wfa/virtual_people/common/event.proto
@@ -110,16 +110,31 @@ message ProfileInfo {
   optional UserInfo proprietary_id_space_10_user_info = 14;
 }
 
-// Carries a pre-computed rank for a specific pool. The pipeline computes ranks
-// externally and injects them into LabelerInput so that RankedPopulationNode
-// can perform collision-free VID assignment via Feistel cipher.
+// Carries a pre-computed rank for a specific pool, injected by the pipeline
+// into LabelerInput before pass-2 labeling. RankedPopulationNode looks up the
+// RankAssignment whose pool_offset matches the node's first pool's
+// population_offset. If a match is found and local_rank < ranked_size, the
+// node uses Feistel bijection for collision-free VID assignment. If no match
+// is found, the node falls back to hash-based assignment.
+//
+// The pipeline is responsible for:
+// 1. Running pass-1 (LABELING_PASS_POOL_IDENTITY) to discover which pool
+//    each event routes to.
+// 2. Building per-pool rank tables (mapping accounts to sequential ranks).
+// 3. Populating rank_assignments on LabelerInput with the correct
+//    pool_offset and local_rank before pass-2.
+// 4. Using the same model version for both passes (pool routing is
+//    deterministic given the same model and input).
 message RankAssignment {
   // Required. The population_offset of the VirtualPersonPool that this rank
-  // applies to. Must match a pool's population_offset in the
-  // RankedPopulationNode that the event routes to.
+  // applies to. The labeler matches this against the pool's
+  // population_offset in the RankedPopulationNode the event routes to.
+  // If no RankAssignment matches, the event gets hash-based VID assignment.
   optional uint64 pool_offset = 1;
 
   // Required. The rank within [0, ranked_size) for the identified pool.
+  // Must be unique per account within a pool to guarantee collision-free
+  // VID assignment.
   optional uint64 local_rank = 2;
 }
 

--- a/src/main/proto/wfa/virtual_people/common/event.proto
+++ b/src/main/proto/wfa/virtual_people/common/event.proto
@@ -123,6 +123,16 @@ message RankAssignment {
   optional uint64 local_rank = 2;
 }
 
+// Controls the labeling pass for the two-pass memoized VID pipeline.
+enum LabelingPass {
+  // Default: full labeling — traverse the tree and assign a VID.
+  LABELING_PASS_UNSPECIFIED = 0;
+  // Pass 1: traverse the tree to leaf nodes but emit pool identity
+  // (PoolAssignment) instead of assigning a VID. The pipeline uses the
+  // pool assignments to build rank tables before pass 2.
+  LABELING_PASS_POOL_IDENTITY = 1;
+}
+
 // Represents input to the labeler.
 // Only contains attributes needed for labeling, including attributes
 // extracted from logs and enriched by profile data.
@@ -156,6 +166,10 @@ message LabelerInput {
   // RankedPopulationNode to look up which pool and rank an event maps to
   // for collision-free (Feistel) VID assignment.
   repeated RankAssignment rank_assignments = 8;
+
+  // Which labeling pass to perform. When set to LABELING_PASS_POOL_IDENTITY,
+  // RankedPopulationNode emits PoolAssignment instead of assigning a VID.
+  LabelingPass labeling_pass = 9;
 }
 
 // LogEvent contains all attributes in LabelerInput, as well as other

--- a/src/main/proto/wfa/virtual_people/common/event.proto
+++ b/src/main/proto/wfa/virtual_people/common/event.proto
@@ -110,6 +110,18 @@ message ProfileInfo {
   optional UserInfo proprietary_id_space_10_user_info = 14;
 }
 
+// Carries a pre-computed rank for a specific pool. The pipeline computes ranks
+// externally and injects them into LabelerInput so that RankedPopulationNode
+// can perform collision-free VID assignment via Feistel cipher.
+message RankAssignment {
+  // Identifies which pool this rank applies to (matches VirtualPersonPool
+  // ordering).
+  uint64 pool_offset = 1;
+
+  // The rank within [0, ranked_size) for the identified pool.
+  uint64 local_rank = 2;
+}
+
 // Represents input to the labeler.
 // Only contains attributes needed for labeling, including attributes
 // extracted from logs and enriched by profile data.
@@ -138,6 +150,11 @@ message LabelerInput {
   // Event information not intended to be used during labeling or in the
   // measurement system.
   optional TrafficInfo traffic_info = 7;
+
+  // Pre-computed rank assignments injected by the pipeline. Used by
+  // RankedPopulationNode to look up which pool and rank an event maps to
+  // for collision-free (Feistel) VID assignment.
+  repeated RankAssignment rank_assignments = 20;
 }
 
 // LogEvent contains all attributes in LabelerInput, as well as other

--- a/src/main/proto/wfa/virtual_people/common/event.proto
+++ b/src/main/proto/wfa/virtual_people/common/event.proto
@@ -114,12 +114,13 @@ message ProfileInfo {
 // externally and injects them into LabelerInput so that RankedPopulationNode
 // can perform collision-free VID assignment via Feistel cipher.
 message RankAssignment {
-  // Identifies which pool this rank applies to (matches VirtualPersonPool
-  // ordering).
-  uint64 pool_offset = 1;
+  // Required. The population_offset of the VirtualPersonPool that this rank
+  // applies to. Must match a pool's population_offset in the
+  // RankedPopulationNode that the event routes to.
+  optional uint64 pool_offset = 1;
 
-  // The rank within [0, ranked_size) for the identified pool.
-  uint64 local_rank = 2;
+  // Required. The rank within [0, ranked_size) for the identified pool.
+  optional uint64 local_rank = 2;
 }
 
 // Represents input to the labeler.

--- a/src/main/proto/wfa/virtual_people/common/event.proto
+++ b/src/main/proto/wfa/virtual_people/common/event.proto
@@ -118,7 +118,7 @@ message ProfileInfo {
 // is found, the node falls back to hash-based assignment.
 //
 // The pipeline is responsible for:
-// 1. Running pass-1 (LABELING_PASS_POOL_IDENTITY) to discover which pool
+// 1. Running the labeler in pool-identity mode to discover which pool
 //    each event routes to.
 // 2. Building per-pool rank tables (mapping accounts to sequential ranks).
 // 3. Populating rank_assignments on LabelerInput with the correct
@@ -136,16 +136,6 @@ message RankAssignment {
   // Must be unique per account within a pool to guarantee collision-free
   // VID assignment.
   optional uint64 local_rank = 2;
-}
-
-// Controls the labeling pass for the two-pass memoized VID pipeline.
-enum LabelingPass {
-  // Default: full labeling — traverse the tree and assign a VID.
-  LABELING_PASS_UNSPECIFIED = 0;
-  // Pass 1: traverse the tree to leaf nodes but emit pool identity
-  // (PoolAssignment) instead of assigning a VID. The pipeline uses the
-  // pool assignments to build rank tables before pass 2.
-  LABELING_PASS_POOL_IDENTITY = 1;
 }
 
 // Represents input to the labeler.
@@ -181,10 +171,6 @@ message LabelerInput {
   // RankedPopulationNode to look up which pool and rank an event maps to
   // for collision-free (Feistel) VID assignment.
   repeated RankAssignment rank_assignments = 8;
-
-  // Which labeling pass to perform. When set to LABELING_PASS_POOL_IDENTITY,
-  // RankedPopulationNode emits PoolAssignment instead of assigning a VID.
-  LabelingPass labeling_pass = 9;
 }
 
 // LogEvent contains all attributes in LabelerInput, as well as other

--- a/src/main/proto/wfa/virtual_people/common/event.proto
+++ b/src/main/proto/wfa/virtual_people/common/event.proto
@@ -154,7 +154,7 @@ message LabelerInput {
   // Pre-computed rank assignments injected by the pipeline. Used by
   // RankedPopulationNode to look up which pool and rank an event maps to
   // for collision-free (Feistel) VID assignment.
-  repeated RankAssignment rank_assignments = 20;
+  repeated RankAssignment rank_assignments = 8;
 }
 
 // LogEvent contains all attributes in LabelerInput, as well as other

--- a/src/main/proto/wfa/virtual_people/common/model.proto
+++ b/src/main/proto/wfa/virtual_people/common/model.proto
@@ -25,17 +25,6 @@ import "wfa/virtual_people/common/event.proto";
 import "wfa/virtual_people/common/field_filter.proto";
 import "wfa/virtual_people/common/label.proto";
 
-// Mode for handling events that fall outside the ranked sub-range.
-enum UnrankedMode {
-  UNRANKED_MODE_UNSPECIFIED = 0;
-  // Unranked events are assigned VIDs from a disjoint pool (no overlap with
-  // ranked VIDs).
-  DISJOINT = 1;
-  // Unranked events are assigned VIDs from the full pool (may overlap with
-  // ranked VIDs).
-  FULL_POOL = 2;
-}
-
 // The node of the VID model tree.
 message CompiledNode {
   optional string name = 1;
@@ -89,11 +78,24 @@ message PopulationNode {
 // assignment. Events outside the ranked sub-range fall back to hash-based
 // assignment controlled by unranked_mode.
 message RankedPopulationNode {
+  // Mode for handling events that fall outside the ranked sub-range.
+  enum UnrankedMode {
+    UNRANKED_MODE_UNSPECIFIED = 0;
+    // Unranked events are assigned VIDs from a disjoint sub-range
+    // [pool_offset + ranked_size, pool_offset + pool_size) — no overlap
+    // with ranked VIDs.
+    DISJOINT = 1;
+    // Unranked events are assigned VIDs from the full pool
+    // [pool_offset, pool_offset + pool_size). This gives unranked events
+    // the lowest collision rate but may overlap with ranked VIDs.
+    FULL_POOL = 2;
+  }
+
   // The pools of VIDs to choose from. Reuses PopulationNode.VirtualPersonPool.
   repeated PopulationNode.VirtualPersonPool pools = 1;
 
   // Random seed for deterministic VID assignment.
-  string random_seed = 2;
+  optional string random_seed = 2;
 
   // Number of VIDs in the ranked (Feistel) sub-range. Events with a rank
   // in [0, ranked_size) get collision-free VID assignment.
@@ -101,12 +103,6 @@ message RankedPopulationNode {
 
   // How to handle events outside the ranked sub-range.
   UnrankedMode unranked_mode = 4;
-
-  // Quantum labels to assign to the virtual person.
-  IndependentQuantumLabels quantum_labels = 5;
-
-  // Classic label attributes to assign to the virtual person.
-  PersonLabelAttributes label = 6;
 }
 
 // BranchNode contains

--- a/src/main/proto/wfa/virtual_people/common/model.proto
+++ b/src/main/proto/wfa/virtual_people/common/model.proto
@@ -25,6 +25,17 @@ import "wfa/virtual_people/common/event.proto";
 import "wfa/virtual_people/common/field_filter.proto";
 import "wfa/virtual_people/common/label.proto";
 
+// Mode for handling events that fall outside the ranked sub-range.
+enum UnrankedMode {
+  UNRANKED_MODE_UNSPECIFIED = 0;
+  // Unranked events are assigned VIDs from a disjoint pool (no overlap with
+  // ranked VIDs).
+  DISJOINT = 1;
+  // Unranked events are assigned VIDs from the full pool (may overlap with
+  // ranked VIDs).
+  FULL_POOL = 2;
+}
+
 // The node of the VID model tree.
 message CompiledNode {
   optional string name = 1;
@@ -39,6 +50,7 @@ message CompiledNode {
     // StopNode and PopulationNode have no child node.
     StopNode stop_node = 4;
     PopulationNode population_node = 5;
+    RankedPopulationNode ranked_population_node = 6;
   }
 
   message DebugInfo {
@@ -69,6 +81,32 @@ message PopulationNode {
   repeated VirtualPersonPool pools = 1;
 
   optional string random_seed = 2;
+}
+
+// Like PopulationNode, but splits VID assignment into ranked (Feistel cipher,
+// collision-free) and unranked (hash-based) sub-ranges. The ranked sub-range
+// uses a format-preserving Feistel bijection for memoized, collision-free VID
+// assignment. Events outside the ranked sub-range fall back to hash-based
+// assignment controlled by unranked_mode.
+message RankedPopulationNode {
+  // The pools of VIDs to choose from. Reuses PopulationNode.VirtualPersonPool.
+  repeated PopulationNode.VirtualPersonPool pools = 1;
+
+  // Random seed for deterministic VID assignment.
+  string random_seed = 2;
+
+  // Number of VIDs in the ranked (Feistel) sub-range. Events with a rank
+  // in [0, ranked_size) get collision-free VID assignment.
+  uint64 ranked_size = 3;
+
+  // How to handle events outside the ranked sub-range.
+  UnrankedMode unranked_mode = 4;
+
+  // Quantum labels to assign to the virtual person.
+  IndependentQuantumLabels quantum_labels = 5;
+
+  // Classic label attributes to assign to the virtual person.
+  PersonLabelAttributes label = 6;
 }
 
 // BranchNode contains

--- a/src/main/proto/wfa/virtual_people/common/model.proto
+++ b/src/main/proto/wfa/virtual_people/common/model.proto
@@ -384,8 +384,4 @@ message LabelerEvent {
 
   // Classic label for person attributes.
   optional PersonLabelAttributes label = 13;
-
-  // Pool assignments emitted by RankedPopulationNode during pass-1
-  // (LABELING_PASS_POOL_IDENTITY). Copied to LabelerOutput by the Labeler.
-  repeated PoolAssignment pool_assignments = 14;
 }

--- a/src/main/proto/wfa/virtual_people/common/model.proto
+++ b/src/main/proto/wfa/virtual_people/common/model.proto
@@ -384,4 +384,8 @@ message LabelerEvent {
 
   // Classic label for person attributes.
   optional PersonLabelAttributes label = 13;
+
+  // Pool assignments emitted by RankedPopulationNode during pass-1
+  // (LABELING_PASS_POOL_IDENTITY). Copied to LabelerOutput by the Labeler.
+  repeated PoolAssignment pool_assignments = 14;
 }


### PR DESCRIPTION
## Summary

Add proto definitions for memoized VID assignment: a new `RankedPopulationNode` that supports collision-free VID assignment via Feistel cipher for ranked events, with configurable fallback for unranked events.

### Changes

**model.proto:**
- `RankedPopulationNode` message — new leaf node type with pools, random_seed, ranked_size, and nested `UnrankedMode` enum (`DISJOINT`, `FULL_POOL`)
- `CompiledNode.type` oneof — add `ranked_population_node` (field 6)

**event.proto:**
- `RankAssignment` message — carries `pool_offset` and `local_rank` for pipeline-injected pre-computed ranks
- `LabelerInput.rank_assignments` (field 8) — pre-computed ranks for pass-2 labeling

### Context

The `RankedPopulationNode` enables:
- **Ranked sub-range**: Feistel bijection for collision-free VID assignment
- **Unranked sub-range**: Hash-based fallback (DISJOINT = separate pool, FULL_POOL = shared pool)

The labeling pass mode (full vs pool-identity) is handled via the Labeler class interface, not in the proto.

## Test Plan

- [x] Proto compilation
- [x] C++ bindings
- [x] Kotlin bindings