### PR TITLE
feat: enable debug trace

### DIFF
--- a/src/main/proto/wfa/virtual_people/common/event.proto
+++ b/src/main/proto/wfa/virtual_people/common/event.proto
@@ -138,6 +138,11 @@ message LabelerInput {
   // Event information not intended to be used during labeling or in the
   // measurement system.
   optional TrafficInfo traffic_info = 7;
+
+  // When true, the labeler populates LabelerOutput.serialized_debug_trace with
+  // a text-format snapshot of the internal LabelerEvent after model
+  // application. Disabled by default to avoid serialization overhead.
+  bool enable_debug_trace = 9;
 }
 
 // LogEvent contains all attributes in LabelerInput, as well as other


### PR DESCRIPTION
# SUMMARY

Adds `bool enable_debug_trace = 9` to `LabelerInput`. When `true`, the labeler                                                                                                                           
  populates `LabelerOutput.serialized_debug_trace` with a text-format dump of the                                                                                                                          
  internal `LabelerEvent`; defaults to `false` to skip the serialization                                                                                                                                   
  overhead. Consumed by world-federation-of-advertisers/virtual-people-core-serving#85. 