### PR TITLE
Upgrade rules_cc from 0.1.0 to 0.1.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ TRUTH_VERSION = "1.4.4"
 # Bazel Central Registry modules.
 bazel_dep(
     name = "rules_cc",
-    version = "0.1.0",
+    version = "0.1.1",
 )
 bazel_dep(
     name = "protobuf",


### PR DESCRIPTION
## Summary

`rules_cc@0.1.0` has been yanked from BCR due to an incompatible change (premature removal of `cc_proto_library` from `defs.bzl`). Downstream repos that depend on `virtual-people-common` fail with:

```
ERROR: Yanked version detected: rules_cc@0.1.0
```

## Test Plan

- [ ] `bazel build //...`