### PR TITLE
Add pool_identity_mode to LabelerEvent

### DIFF
--- a/src/main/proto/wfa/virtual_people/common/model.proto
+++ b/src/main/proto/wfa/virtual_people/common/model.proto
@@ -385,7 +385,11 @@ message LabelerEvent {
   // Classic label for person attributes.
   optional PersonLabelAttributes label = 13;
 
-  // Pool assignments emitted by RankedPopulationNode during pass-1
-  // (LABELING_PASS_POOL_IDENTITY). Copied to LabelerOutput by the Labeler.
+  // Pool assignments emitted by RankedPopulationNode during pass-1.
+  // Copied to LabelerOutput by the Labeler.
   repeated PoolAssignment pool_assignments = 14;
+
+  // When true, RankedPopulationNode emits PoolAssignment instead of
+  // assigning a VID. Set by the Labeler when running in pool-identity mode.
+  optional bool pool_identity_mode = 15;
 }


### PR DESCRIPTION
## Summary

Add `pool_identity_mode` (field 15) to `LabelerEvent`. This internal field is set by the Labeler when running in pool-identity mode. `RankedPopulationNode` checks it to emit `PoolAssignment` instead of assigning a VID.

This enables the two-pass memoized VID assignment pipeline: pass-1 identifies pools, the pipeline computes ranks, pass-2 assigns VIDs.

## Test Plan

- [ ] Proto compilation
- [ ] C++ and Kotlin bindings