### PR TITLE
feat: add memoized_rank_fallback signal to VirtualPersonActivity

### DIFF
--- a/src/main/proto/wfa/virtual_people/common/label.proto
+++ b/src/main/proto/wfa/virtual_people/common/label.proto
@@ -68,11 +68,12 @@ message VirtualPersonActivity {
     PersonLabelAttributes label = 3;
   }
 
-  // Whether the memoized rank path was attempted for this activity but had to
-  // fall back to the hash path because no LabelerInput.rank_assignments entry
-  // matched the leaf's pool_offset. True only on memoized model lines: false
-  // when no rank_assignments were provided (caller did not attempt memoization)
-  // and false when memoization succeeded (Feistel VID assigned).
+  // Whether the memoized rank path was attempted for this activity but the
+  // leaf used the hash path: either no LabelerInput.rank_assignments entry
+  // matched the leaf's pool_offset, or a matching entry's local_rank fell
+  // outside [0, ranked_size). True only on memoized model lines: false when no
+  // rank_assignments were provided (caller did not attempt memoization) and
+  // false when memoization succeeded (Feistel VID assigned).
   //
   // The dominant cause of this flag firing is Phase-1 overflow: the subpool
   // reached ranked_size and this fingerprint was one of the unranked surplus,

--- a/src/main/proto/wfa/virtual_people/common/label.proto
+++ b/src/main/proto/wfa/virtual_people/common/label.proto
@@ -67,6 +67,21 @@ message VirtualPersonActivity {
     // Could be the result of the collapse of quantum_label.
     PersonLabelAttributes label = 3;
   }
+
+  // Whether the memoized rank path was attempted for this activity but had to
+  // fall back to the hash path because no LabelerInput.rank_assignments entry
+  // matched the leaf's pool_offset. True only on memoized model lines: false
+  // when no rank_assignments were provided (caller did not attempt memoization)
+  // and false when memoization succeeded (Feistel VID assigned).
+  //
+  // The dominant cause of this flag firing is Phase-1 overflow: the subpool
+  // reached ranked_size and this fingerprint was one of the unranked surplus,
+  // so the subpool has no rank for it (per the design's
+  // overflow-fps-fall-back-to-unranked-path contract). Consumers should
+  // aggregate this into a counter tagged by (data provider, model line, pool
+  // offset) to alarm on a rising memoized-fallback rate, which indicates a
+  // subpool's ranked_size should be raised.
+  bool memoized_rank_fallback = 4;
 }
 
 // Identifies a pool and its ranked sub-range, emitted during pass-1 mode.


### PR DESCRIPTION
Adds a boolean on `VirtualPersonActivity` that the labeler sets when the memoized rank path was attempted (`LabelerInput.rank_assignments` non-empty) but the leaf had to fall back to the hash path because no entry matched its `pool_offset`. The dominant cause is Phase-1 overflow: the subpool reached `ranked_size` and this fingerprint was one of the unranked surplus, so the subpool has no rank for it.

Without this signal, the memoized Phase-2 pipeline silently degrades to hash-based VID assignment when subpools saturate, with no operational visibility. The consumer (the VID Labeler in `cross-media-measurement`) aggregates this per `(data provider, model line, pool offset)` into an OpenTelemetry counter to alarm on a rising fallback rate — the indicator that a subpool's `ranked_size` should be raised.

Companion PR in `virtual-people-core-serving` will set the field in both C++ and Kotlin `RankedPopulationNodeImpl`. Consumer wiring lands in `cross-media-measurement#4072`.

Related: world-federation-of-advertisers/cross-media-measurement#4073
