### PR TITLE
feat: add placement field to LabelerInput

### DIFF
--- a/src/main/proto/wfa/virtual_people/common/event.proto
+++ b/src/main/proto/wfa/virtual_people/common/event.proto
@@ -176,6 +176,13 @@ message LabelerInput {
   // a text-format snapshot of the internal LabelerEvent after model
   // application. Disabled by default to avoid serialization overhead.
   bool enable_debug_trace = 9;
+
+  // Ad placement or surface on which the event occurred, e.g. a
+  // publisher's feed, reels, or stories surface. Carried as an opaque
+  // string so it can hold any publisher's placement taxonomy without this
+  // proto enumerating them. The labeler may route on this via field
+  // filters. Populated from the raw event by the pipeline.
+  optional string placement = 10;
 }
 
 // LogEvent contains all attributes in LabelerInput, as well as other


### PR DESCRIPTION
Adds optional string placement = 10 to LabelerInput. It carries the ad placement or surface on which an event occurred (for example a publishers feed, reels, or stories surface) so the labeler can route on it via field filters. It is an opaque string rather than an enum so it can hold any publishers placement taxonomy without this proto enumerating them, and is populated from the raw event by the pipeline.

Issue: https://github.com/world-federation-of-advertisers/virtual-people-common/issues/78