### PR TITLE
feat: add placement field to LabelerEvent

### DIFF
--- a/src/main/proto/wfa/virtual_people/common/model.proto
+++ b/src/main/proto/wfa/virtual_people/common/model.proto
@@ -392,4 +392,11 @@ message LabelerEvent {
   // When true, RankedPopulationNode emits PoolAssignment instead of
   // assigning a VID. Set by the Labeler when running in pool-identity mode.
   optional bool pool_identity_mode = 15;
+
+  // Ad placement or surface on which the event occurred, e.g. a
+  // publisher's feed, reels, or stories surface. Carried as an opaque
+  // string so it can hold any publisher's placement taxonomy without this
+  // proto enumerating them. The labeler may route on this via field
+  // filters. Populated from LabelerInput.placement.
+  optional string placement = 16;
 }


### PR DESCRIPTION
Adds optional string placement = 16 to LabelerEvent. It carries the ad placement or surface on which an event occurred (for example a publisher's feed, reels, or stories surface) so the labeler can route on it via field filters. It is an opaque string rather than an enum so it can hold any publisher's placement taxonomy without this proto enumerating them. It mirrors the placement field added to LabelerInput in #76 and is populated from LabelerInput.placement.

Issue: https://github.com/world-federation-of-advertisers/virtual-people-common/issues/78
Closes: https://github.com/world-federation-of-advertisers/virtual-people-common/issues/78